### PR TITLE
Divide hw.memsize by 1073741824 for expected GB results

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -16,7 +16,7 @@ packagehandler=""
 cpu=$(echo "$cpu" | awk '$1=$1' | sed 's/([A-Z]\{1,2\})//g')
 
 mem=$(sysctl -n hw.memsize)
-ram="$((mem/1000000000)) GB"
+ram="$((mem/1073741824)) GB"
 disk=`df | head -2 | tail -1 | awk '{print $5}'`
 
 # Colors Variables


### PR DESCRIPTION
Dividing the number of bytes returned from `sysctl hw.memsize` by
1.0x10^9 gives unexpected results on machines with a large amount of
RAM. For example, on a 16GB system, `archey` will report **17 GB**.
Dividing by 1073741824 (i.e., 1024^3) yields the expected results.
