### PR TITLE
Replaced tabs in output with spaces (not all terminals have a tab-width of 8)

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -67,7 +67,7 @@ diskText="${textColor}Disk:${normal}"
 echo -e "
 
 ${GREEN}                 ###
-${GREEN}               ####	              $userText $user
+${GREEN}               ####                   $userText $user
 ${GREEN}               ###                    $hostnameText $hostname
 ${GREEN}       #######    #######             $distroText $distro
 ${YELLOW}     ######################           $kernelText $kernel
@@ -76,7 +76,7 @@ ${LRED}    ####################              $shellText $shell
 ${RED}    ####################              $terminalText $terminal
 ${RED}    #####################             $packagehandlerText $packagehandler
 ${PURPLE}     ######################           $cpuText $cpu
-${PURPLE}      ####################	      $memoryText $ram
+${PURPLE}      ####################            $memoryText $ram
 ${BLUE}        ################              $diskText $disk
 ${BLUE}         ####     ##### ${normal}
 


### PR DESCRIPTION
There were two tab characters in `bin/archey`, and so if your tab width is not set to 8, the text on the right does not line up.
