### PR TITLE
Fix for off by one error

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -88,7 +88,7 @@ fi
 
 case "${packager}" in
   homebrew)
-    packagehandler=$(brew list -l | wc -l | awk '{print $1 }')
+    packagehandler=$(brew list -1 | wc -l | awk '{print $1 }')
     ;;
   macports)
     packagehandler=$(port installed | wc -l | awk '{print $1 }')


### PR DESCRIPTION
`brew list -l | wc -l` counts the total 0 line, which is one too many!
