### PR TITLE
Configure logo file location via $ARCHEY_LOGO_FILE

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -101,9 +101,10 @@ memoryText="${textColor}Memory:${normal} ${ram}${normal}"
 diskText="${textColor}Disk:${normal} ${disk}${normal}"
 batteryText="${textColor}Battery:${normal} ${battery}${normal}"
 
-if [ -a "${HOME}/.config/archey-logo" ]
+logofile=${ARCHEY_LOGO_FILE:-"${HOME}/.config/archey-logo"}
+if [ -a "$logofile" ]
   then
-  source "${HOME}/.config/archey-logo"
+  source "$logofile"
 else
 # The ${foo#  } is a cheat so that it lines up here as well
 # as when run.


### PR DESCRIPTION
Hello. This PR builds off of https://github.com/obihann/archey-osx/pull/15, but makes the file location configurable via an `ARCHEY_LOGO_FILE` environment variable. The script will default to the current location (`$HOME/.config/archey-logo`) if the variable is not set.

This is beneficial to those of us who keep our dotfiles in version control, but do not want to put all of `~/.config` in there.