### PR TITLE
Remove dependency on outbound DNS

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -69,7 +69,7 @@ if [[ "${opt_offline}" = f ]]; then
             ip="$line"
         done < "$ipfile"
     else
-        ip=$(dig +short myip.opendns.com @resolver1.opendns.com)
+        ip=$(curl -sS eth0.me)
         echo $ip > "$ipfile"
     fi
 fi


### PR DESCRIPTION
Some people (including myself) operate their own DNS servers internally and block outbound port 53.  This currently causes the first time you run archey take a long time until it times out and fails to gather the public IP.  By using one of the faster free public IP response services that works via HTTP, this can be worked around.

I understand why dig was used, but in my tests eth0.me is just as fast without the dependency.