### PR TITLE
Fix battery showing with double %

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -130,7 +130,11 @@ fieldlist[${#fieldlist[@]}]="${textColor}CPU:${normal} ${cpu}${normal}"
 fieldlist[${#fieldlist[@]}]="${textColor}Memory:${normal} ${ram}${normal}"
 fieldlist[${#fieldlist[@]}]="${textColor}Disk:${normal} ${disk}${normal}"
 if [[ ! -z $battery ]]; then
+    if [ "${battery: -1}" == "%" ]; then
+    fieldlist[${#fieldlist[@]}]="${textColor}Battery:${normal} ${battery}${normal}"
+else
     fieldlist[${#fieldlist[@]}]="${textColor}Battery:${normal} ${battery}${normal}%"
+    fi
 fi
 if [ "${opt_offline}" = f ]; then
     fieldlist[${#fieldlist[@]}]="${textColor}IP Address:${normal} ${ip}${normal}"


### PR DESCRIPTION
This will fix issue #54 by checking to see if we already have a % sign before outputting to display. There is probably a nicer way to do this, but here ya go