### PR TITLE
Switch eth0.me to using myip.opendns.com (fixes #61)

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -73,7 +73,7 @@ if [[ "${opt_offline}" = f ]]; then
             ip="$line"
         done < "$ipfile"
     else
-        ip=$(curl -sS eth0.me)
+        ip=$(dig +short myip.opendns.com @resolver1.opendns.com)
         echo $ip > "$ipfile"
     fi
 fi


### PR DESCRIPTION
Pretty sure `dig` works on most if not all versions of macOS.

Fixes #61.