### PR TITLE
Fix uptime display in Sierra

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -87,7 +87,7 @@ fi
 
 distro="OS X $(sw_vers -productVersion)"
 kernel=$(uname)
-uptime=$(uptime | sed -e 's/.*up //' -e 's/, [0-9]* user.*//')
+uptime=$(uptime | sed -e 's/.*up\s*//' -e 's/,\s*[0-9]* user.*//')
 shell="$SHELL"
 terminal="$TERM ${TERM_PROGRAM//_/ }"
 cpu=$(sysctl -n machdep.cpu.brand_string)


### PR DESCRIPTION
- Use \s to match all whitespace instead of a single hardcoded space