### PR TITLE
Silence uptime stderr

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -87,7 +87,7 @@ fi
 
 distro="OS X $(sw_vers -productVersion)"
 kernel=$(uname)
-uptime=$(uptime | sed -e 's/.*up //' -e 's/, [0-9]* user.*//')
+uptime=$(uptime 2> /dev/null | sed -e 's/.*up //' -e 's/, [0-9]* user.*//')
 shell="$SHELL"
 terminal="$TERM ${TERM_PROGRAM//_/ }"
 cpu=$(sysctl -n machdep.cpu.brand_string)


### PR DESCRIPTION
Uptime often outputs errors such as
`uptime: /dev/ttys005: No such file or directory`
`uptime: /dev/ttys006: No such file or directory`
after terminals have been opened and closed over several days, and this PR simply redirects `stderr` to `/dev/null` just to shut the thing up.