### PR TITLE
Use [[:space:]] instead of \s for uptime sed

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -99,7 +99,7 @@ fi
 
 distro="macOS $(sw_vers -productVersion)"
 kernel=$(uname)
-uptime=$(uptime 2> /dev/null | sed -e 's/.*up\s*//' -e 's/,\s*[0-9]* user.*//')
+uptime=$(uptime 2> /dev/null | sed -e 's/.*up[[:space:]]*//' -e 's/,[[:space:]]*[0-9]* user.*//')
 shell="$SHELL"
 terminal="$TERM ${TERM_PROGRAM//_/ }"
 cpu=$(sysctl -n machdep.cpu.brand_string)


### PR DESCRIPTION
Commit 4017061 broke the Uptime line for me, because `\s` is not understood by the default macOS `sed` command (this was 10.12.5). Using the POSIX `[[:space:]]` character class works fine.