### PR TITLE
Add better method to check ip and location workaround.

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -47,7 +47,7 @@ do
       echo "  -m --macports  Force use MacPorts as package system."
       echo "  -b --nocolor   Turn color off."
       echo "  -c --color     Force the color on (overrides --nocolor)."
-      echo "  -o --offline   Disable the IP address check."
+      echo "  -o --offline   Disable the IP address and location check."
       exit 0
       ;;
     *)
@@ -81,6 +81,10 @@ if [[ "${opt_offline}" = f ]]; then
       echo $country >> "$infofile"
       echo $city >> "$infofile"
     fi
+    # Get the interface used for the default route
+    activeadapter=$(route -n get 0.0.0.0 | awk '/interface: / {print $2}')
+    # Now get the IP address assigned to that interface
+    localip=$(ifconfig ${activeadapter} | awk '/inet / {print $2}')
 fi
 
 distro="macOS $(sw_vers -productVersion)"
@@ -142,10 +146,9 @@ if [[ ! -z $battery ]]; then
     fieldlist[${#fieldlist[@]}]="${textColor}Battery:${normal} ${battery}%${normal}"
 fi
 if [ "${opt_offline}" = f ]; then
-    fieldlist[${#fieldlist[@]}]="${textColor}IP Address:${normal} ${ip}${normal}"
+    fieldlist[${#fieldlist[@]}]="${textColor}IP Address:${normal} ${ip}, ${localip}${normal}"
     fieldlist[${#fieldlist[@]}]="${textColor}Location:${normal} ${country}, ${city}${normal}"
 fi
-
 logofile=${ARCHEY_LOGO_FILE:-"${HOME}/.config/archey-logo"}
 if [ -a "$logofile" ]
   then

--- a/bin/archey
+++ b/bin/archey
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# archey-osx 1.6.1 (https://github.com/obihann/archey-osx/)
+# archey-osx 1.6.0 (https://github.com/obihann/archey-osx/)
 
 # test to see if bash supports arrays
 arraytest[0]='test' || (echo 'Error: Arrays are not supported in this version of
@@ -37,12 +37,9 @@ do
       ;;
     -o|--offline)
         opt_offline=t
-        ;;
-    -l|--localip)
-		opt_localip=t
       ;;
     -h|--help)
-      echo "Archey OS X 1.6.1"
+      echo "Archey OS X 1.6.0"
       echo
       echo "Usage: $0 [options]"
       echo
@@ -51,7 +48,6 @@ do
       echo "  -b --nocolor   Turn color off."
       echo "  -c --color     Force the color on (overrides --nocolor)."
       echo "  -o --offline   Disable the IP address check."
-      echo "  -l --localip   Show local IP adddress"
       exit 0
       ;;
     *)
@@ -66,40 +62,29 @@ done
 user=$(whoami)
 hostname=$(hostname | sed 's/.local//g')
 
-# v4 and v6 address detection
 if [[ "${opt_offline}" = f ]]; then
-    ipfile4="${HOME}/.archey-ipv4"
-    ipfile6="${HOME}/.archey-ipv6"
-    if [ -a "$ipfile4" ] && test `find "$ipfile4" -mmin -360`; then
-        while read -r line; do
-            V4="$line"
-        done < "$ipfile4"
+    ipfile="${HOME}/config/.archey-info"
+    if [ -a "$ipfile" ] && test `find "$ipfile" -mmin -360`; then
+      while read -r line1; do
+        read line2
+        read line3
+        ip="$line1"
+        country="$line2"
+        city="$line3"
+      done < "$ipfile"
     else
-        if V4=$(curl -sS --max-time 5 https://4.ifcfg.me/ 2>/dev/null); then
-            echo $V4 > "$ipfile4"
-        fi
-    fi
-    if [ -a "$ipfile6" ] && test `find "$ipfile6" -mmin -360`; then
-        while read -r line; do
-            V6="$line"
-        done < "$ipfile6"
-    else
-        if V6=$(curl -sS --max-time 5 https://6.ifcfg.me/ 2>/dev/null); then
-            echo $V6 > "$ipfile6"
-        fi
+      ip=$(curl -sS ifconfig.co)
+      counrty=$(curl -sS ifconfig.co/country)
+      city=$(curl -sS ifconfig.co/city)
+      echo $ip >> "$ipfile"
+      echo $country >> "$ipfile"
+      echo $city >> "$ipfile"
     fi
 fi
 
-if [[ "${opt_localip}" = t ]]; then
-	# Get the interface used for the default route
-	activeadapter=$(route -n get 0.0.0.0 | awk '/interface: / {print $2}')
-	# Now get the IP address assigned to that interface
-	localip=$(ifconfig ${activeadapter} | awk '/inet / {print $2}')
-fi
-
-distro="macOS $(sw_vers -productVersion)"
+distro="OS X $(sw_vers -productVersion)"
 kernel=$(uname)
-uptime=$(uptime 2> /dev/null | sed -e 's/.*up\s*//' -e 's/,\s*[0-9]* user.*//')
+uptime=$(uptime | sed 's/.*up \([^,]*\), .*/\1/')
 shell="$SHELL"
 terminal="$TERM ${TERM_PROGRAM//_/ }"
 cpu=$(sysctl -n machdep.cpu.brand_string)
@@ -153,19 +138,11 @@ fieldlist[${#fieldlist[@]}]="${textColor}CPU:${normal} ${cpu}${normal}"
 fieldlist[${#fieldlist[@]}]="${textColor}Memory:${normal} ${ram}${normal}"
 fieldlist[${#fieldlist[@]}]="${textColor}Disk:${normal} ${disk}${normal}"
 if [[ ! -z $battery ]]; then
-    fieldlist[${#fieldlist[@]}]="${textColor}Battery:${normal} ${battery}%${normal}"
+    fieldlist[${#fieldlist[@]}]="${textColor}Battery:${normal} ${battery}%${normal}%"
 fi
-# Texts had to be shortend to fit in 80 window
 if [ "${opt_offline}" = f ]; then
-    if [ ! -z "$V4" ]; then
-      fieldlist[${#fieldlist[@]}]="${textColor}IPv4:${normal} ${V4}${normal}"
-    fi
-    if [ ! -z "$V6" ]; then
-      fieldlist[${#fieldlist[@]}]="${textColor}IPv6:${normal} ${V6}${normal}"
-    fi
-fi
-if [ "${opt_localip}" = t ]; then
-	fieldlist[${#fieldlist[@]}]="${textColor}Local IP:${normal} ${localip}${normal}"
+    fieldlist[${#fieldlist[@]}]="${textColor}IP Address:${normal} ${ip}${normal}"
+    fieldlist[${#fieldlist[@]}]="${textColor}Location:${normal} ${country}, ${city}${normal}"
 fi
 
 logofile=${ARCHEY_LOGO_FILE:-"${HOME}/.config/archey-logo"}
@@ -176,19 +153,19 @@ else
 # The ${foo#  } is a cheat so that it lines up here as well
 # as when run.
   echo -e "
-${GREEN#  }                 ###               ${fieldlist[0]}
-${GREEN#  }               ####                ${fieldlist[1]}
-${GREEN#  }               ###                 ${fieldlist[2]}
-${GREEN#  }       #######    #######          ${fieldlist[3]}
-${YELLOW# }     ######################        ${fieldlist[4]}
-${YELLOW# }    #####################          ${fieldlist[5]}
-${RED#    }    ####################           ${fieldlist[6]}
-${RED#    }    ####################           ${fieldlist[7]}
-${RED#    }    #####################          ${fieldlist[8]}
-${PURPLE# }     ######################        ${fieldlist[9]}
-${PURPLE# }      ####################         ${fieldlist[10]}
-${BLUE#   }        ################           ${fieldlist[11]}
-${BLUE#   }         ####     #####            ${fieldlist[12]}
+${GREEN#  }                 ###                  ${fieldlist[0]}
+${GREEN#  }               ####                   ${fieldlist[1]}
+${GREEN#  }               ###                    ${fieldlist[2]}
+${GREEN#  }       #######    #######             ${fieldlist[3]}
+${YELLOW# }     ######################           ${fieldlist[4]}
+${YELLOW# }    #####################             ${fieldlist[5]}
+${RED#    }    ####################              ${fieldlist[6]}
+${RED#    }    ####################              ${fieldlist[7]}
+${RED#    }    #####################             ${fieldlist[8]}
+${PURPLE# }     ######################           ${fieldlist[9]}
+${PURPLE# }      ####################            ${fieldlist[10]}
+${BLUE#   }        ################              ${fieldlist[11]}
+${BLUE#   }         ####     #####               ${fieldlist[12]}
 ${normal}
 "
 fi

--- a/bin/archey
+++ b/bin/archey
@@ -39,7 +39,7 @@ do
         opt_offline=t
       ;;
     -h|--help)
-      echo "Archey OS X 1.6.0"
+      echo "Archey OS X 1.6.1"
       echo
       echo "Usage: $0 [options]"
       echo
@@ -63,28 +63,29 @@ user=$(whoami)
 hostname=$(hostname | sed 's/.local//g')
 
 if [[ "${opt_offline}" = f ]]; then
-    ipfile="${HOME}/config/.archey-info"
-    if [ -a "$ipfile" ] && test `find "$ipfile" -mmin -360`; then
+    infofile="${HOME}/.config/.archey-info"
+    if [ -a "$infofile" ] && test `find "$infofile" -mmin -360`; then
       while read -r line1; do
         read line2
         read line3
         ip="$line1"
         country="$line2"
         city="$line3"
-      done < "$ipfile"
+      done < "$infofile"
     else
-      ip=$(curl -sS ifconfig.co)
-      counrty=$(curl -sS ifconfig.co/country)
-      city=$(curl -sS ifconfig.co/city)
-      echo $ip >> "$ipfile"
-      echo $country >> "$ipfile"
-      echo $city >> "$ipfile"
+      info=$(curl -sS --max-time 5 ifconfig.co/json)
+      ip=$(echo $info | $(which jq) --raw-output '.ip')
+      country=$(echo $info | $(which jq) --raw-output '.country')
+      city=$(echo $info | $(which jq) --raw-output '.city')
+      echo $ip >> "$infofile"
+      echo $country >> "$infofile"
+      echo $city >> "$infofile"
     fi
 fi
 
-distro="OS X $(sw_vers -productVersion)"
+distro="macOS $(sw_vers -productVersion)"
 kernel=$(uname)
-uptime=$(uptime | sed 's/.*up \([^,]*\), .*/\1/')
+uptime=$(uptime 2> /dev/null | sed -e 's/.*up\s*//' -e 's/,\s*[0-9]* user.*//')
 shell="$SHELL"
 terminal="$TERM ${TERM_PROGRAM//_/ }"
 cpu=$(sysctl -n machdep.cpu.brand_string)
@@ -138,7 +139,7 @@ fieldlist[${#fieldlist[@]}]="${textColor}CPU:${normal} ${cpu}${normal}"
 fieldlist[${#fieldlist[@]}]="${textColor}Memory:${normal} ${ram}${normal}"
 fieldlist[${#fieldlist[@]}]="${textColor}Disk:${normal} ${disk}${normal}"
 if [[ ! -z $battery ]]; then
-    fieldlist[${#fieldlist[@]}]="${textColor}Battery:${normal} ${battery}%${normal}%"
+    fieldlist[${#fieldlist[@]}]="${textColor}Battery:${normal} ${battery}%${normal}"
 fi
 if [ "${opt_offline}" = f ]; then
     fieldlist[${#fieldlist[@]}]="${textColor}IP Address:${normal} ${ip}${normal}"

--- a/bin/archey
+++ b/bin/archey
@@ -154,19 +154,19 @@ else
 # The ${foo#  } is a cheat so that it lines up here as well
 # as when run.
   echo -e "
-${GREEN#  }                 ###                  ${fieldlist[0]}
-${GREEN#  }               ####                   ${fieldlist[1]}
-${GREEN#  }               ###                    ${fieldlist[2]}
-${GREEN#  }       #######    #######             ${fieldlist[3]}
-${YELLOW# }     ######################           ${fieldlist[4]}
-${YELLOW# }    #####################             ${fieldlist[5]}
-${RED#    }    ####################              ${fieldlist[6]}
-${RED#    }    ####################              ${fieldlist[7]}
-${RED#    }    #####################             ${fieldlist[8]}
-${PURPLE# }     ######################           ${fieldlist[9]}
-${PURPLE# }      ####################            ${fieldlist[10]}
-${BLUE#   }        ################              ${fieldlist[11]}
-${BLUE#   }         ####     #####               ${fieldlist[12]}
+${GREEN#  }                 ###               ${fieldlist[0]}
+${GREEN#  }               ####                ${fieldlist[1]}
+${GREEN#  }               ###                 ${fieldlist[2]}
+${GREEN#  }       #######    #######          ${fieldlist[3]}
+${YELLOW# }     ######################        ${fieldlist[4]}
+${YELLOW# }    #####################          ${fieldlist[5]}
+${RED#    }    ####################           ${fieldlist[6]}
+${RED#    }    ####################           ${fieldlist[7]}
+${RED#    }    #####################          ${fieldlist[8]}
+${PURPLE# }     ######################        ${fieldlist[9]}
+${PURPLE# }      ####################         ${fieldlist[10]}
+${BLUE#   }        ################           ${fieldlist[11]}
+${BLUE#   }         ####     #####            ${fieldlist[12]}
 ${normal}
 "
 fi


### PR DESCRIPTION
Change:  
+ ifconfig.co/json to queue IP and location info, narrow down to 1 curl request.
+ Public and local IP will display in the same line.
+ Help message, offline mode will also disable local IP check.
+ Help message, fix a typo
+ .archey-ip file, renamed it to .archey-info and storage in ~/.config/, with logo file.

Removed:
+  ipv4, ipv6 method:
     I can't find another service is able to use subdomains to check ipv4, 6 address, also ifconfig.co
     disabled this feature as I quote:
> As of 2018-07-25 it's no longer possible to force protocol using the v4 and v6 subdomains.



I don't have ipv6 to test but if someone does, 
comment callback from `ifconfig.co/json`, please.